### PR TITLE
feat: 클라이언트 및 NodeJs서버 API 연동 

### DIFF
--- a/client/deepsleep-client/src/lib/api-config.ts
+++ b/client/deepsleep-client/src/lib/api-config.ts
@@ -1,0 +1,23 @@
+// API 기본 설정
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+
+// API 엔드포인트
+export const API_ENDPOINTS = {
+  // 수면 환경 상태
+  SLEEP_STATUS: `${API_BASE_URL}/sleep/status`,
+  SLEEP_RECORDS: `${API_BASE_URL}/sleep/records`,
+  
+  // 디바이스 제어
+  HUMIDIFIER_CONTROL: `${API_BASE_URL}/device/humidifier`,
+  SPEAKER_CONTROL: `${API_BASE_URL}/device/speaker`,
+  
+  // 자동화 설정
+  AUTOMATION_SETTINGS: `${API_BASE_URL}/settings/automation`,
+  
+  // AI 수면환경 분석
+  SLEEP_ANALYSIS: {
+    INSIGHTS: `${API_BASE_URL}/sleep-analysis/insights`,
+    PREDICTION: `${API_BASE_URL}/sleep-analysis/prediction`,
+    TRENDS: `${API_BASE_URL}/sleep-analysis/trends`,
+  }
+}; 

--- a/client/deepsleep-client/src/lib/api-service.ts
+++ b/client/deepsleep-client/src/lib/api-service.ts
@@ -1,0 +1,102 @@
+import axios from 'axios';
+import { API_ENDPOINTS } from './api-config';
+
+// axios 기본 설정
+axios.defaults.withCredentials = true;
+
+// 수면 환경 상태 조회
+export const getSleepStatus = async () => {
+  try {
+    const response = await axios.get(API_ENDPOINTS.SLEEP_STATUS);
+    return response.data;
+  } catch (error) {
+    console.error('수면 환경 상태 조회 실패:', error);
+    throw error;
+  }
+};
+
+// 수면 데이터 기록 조회
+export const getSleepRecords = async () => {
+  try {
+    const response = await axios.get(API_ENDPOINTS.SLEEP_RECORDS);
+    return response.data;
+  } catch (error) {
+    console.error('수면 데이터 기록 조회 실패:', error);
+    throw error;
+  }
+};
+
+// 가습기 제어
+export const controlHumidifier = async (status: 'on' | 'off') => {
+  try {
+    const response = await axios.post(API_ENDPOINTS.HUMIDIFIER_CONTROL, { status });
+    return response.data;
+  } catch (error) {
+    console.error('가습기 제어 실패:', error);
+    throw error;
+  }
+};
+
+// 스피커 제어
+export const controlSpeaker = async (status: 'on' | 'off', volume?: number) => {
+  try {
+    const response = await axios.post(API_ENDPOINTS.SPEAKER_CONTROL, { status, volume });
+    return response.data;
+  } catch (error) {
+    console.error('스피커 제어 실패:', error);
+    throw error;
+  }
+};
+
+// 자동화 설정 저장
+export interface AutomationSettings {
+  enabled: boolean;
+  humidityThreshold: number;
+  heartRateThreshold: number;
+}
+
+export const saveAutomationSettings = async (settings: AutomationSettings) => {
+  try {
+    const response = await axios.post(API_ENDPOINTS.AUTOMATION_SETTINGS, settings);
+    return response.data;
+  } catch (error) {
+    console.error('자동화 설정 저장 실패:', error);
+    throw error;
+  }
+};
+
+// AI 수면환경 분석 API
+export const sleepAnalysisApi = {
+  // 인사이트 조회
+  getInsights: async (data: any) => {
+    try {
+      const response = await axios.post(API_ENDPOINTS.SLEEP_ANALYSIS.INSIGHTS, data);
+      return response.data;
+    } catch (error) {
+      console.error('수면 인사이트 조회 실패:', error);
+      throw error;
+    }
+  },
+
+  // 예측 조회
+  getPrediction: async (data: any) => {
+    try {
+      const response = await axios.post(API_ENDPOINTS.SLEEP_ANALYSIS.PREDICTION, data);
+      return response.data;
+    } catch (error) {
+      console.error('수면 예측 조회 실패:', error);
+      throw error;
+    }
+  },
+
+  // 트렌드 조회
+  getTrends: async (data: any) => {
+    try {
+      const response = await axios.post(API_ENDPOINTS.SLEEP_ANALYSIS.TRENDS, data);
+      return response.data;
+    } catch (error) {
+      console.error('수면 트렌드 조회 실패:', error);
+      throw error;
+    }
+  }
+}; 

--- a/client/deepsleep-client/src/lib/sleep-analysis-api.ts
+++ b/client/deepsleep-client/src/lib/sleep-analysis-api.ts
@@ -1,3 +1,5 @@
+import { API_ENDPOINTS } from './api-config'
+
 // 클라이언트에서 Node.js 서버로 보낼 API 요청 타입들
 
 export interface SleepAnalysisRequest {
@@ -22,11 +24,11 @@ export interface InsightsResponse {
   data: {
     insights: Array<{
       id: string
-      type: "positive" | "warning" | "suggestion"
+      type: 'info' | 'warning' | 'alert'
+      priority: 'low' | 'medium' | 'high'
       title: string
       description: string
       confidence: number
-      priority: "high" | "medium" | "low"
     }>
     generatedAt: string
   }
@@ -40,8 +42,8 @@ export interface PredictionResponse {
     reasoning: string
     factors: Array<{
       name: string
-      impact: "positive" | "negative" | "neutral"
       value: string
+      impact: 'positive' | 'negative' | 'neutral'
       explanation: string
     }>
     generatedAt: string
@@ -56,13 +58,13 @@ export interface TrendsResponse {
     humidityTrend: {
       current: number
       weeklyAverage: number
-      trend: "improving" | "declining" | "stable"
+      trend: 'improving' | 'declining' | 'stable'
       analysis: string
     }
     heartRateTrend: {
       current: number
       weeklyAverage: number
-      trend: "improving" | "declining" | "stable"
+      trend: 'improving' | 'declining' | 'stable'
       analysis: string
     }
     generatedAt: string
@@ -70,120 +72,10 @@ export interface TrendsResponse {
   error?: string
 }
 
-// 임시 더미 데이터 (실제 서버 응답 형태)
-const DUMMY_RESPONSES = {
-  insights: {
-    success: true,
-    data: {
-      insights: [
-        {
-          id: "humidity-analysis-001",
-          type: "warning" as const,
-          title: "습도 변동이 수면 품질에 영향을 줄 수 있습니다",
-          description:
-            "현재 습도 45%는 적정 범위이지만, 최근 3일간 38%~52% 사이에서 큰 변동을 보이고 있습니다. 일정한 습도 유지를 위해 가습기 자동화 설정을 더 세밀하게 조정하는 것을 권장합니다.",
-          confidence: 87,
-          priority: "medium" as const,
-        },
-        {
-          id: "heartrate-analysis-001",
-          type: "positive" as const,
-          title: "심박수가 이상적인 수면 준비 상태를 보여줍니다",
-          description:
-            "현재 심박수 65bpm은 수면 전 최적 상태입니다. 지난 주 평균 68bpm에서 3bpm 감소하여 스트레스 관리와 이완 기법이 효과적으로 작용하고 있는 것으로 분석됩니다.",
-          confidence: 92,
-          priority: "low" as const,
-        },
-        {
-          id: "device-optimization-001",
-          type: "suggestion" as const,
-          title: "스피커 볼륨 최적화로 더 나은 수면 효과를 기대할 수 있습니다",
-          description:
-            "현재 볼륨 30%는 적절하나, 수면 단계별 볼륨 조절을 통해 더 효과적인 수면 유도가 가능합니다. 입면 시 25%, 깊은 수면 단계에서는 15%로 점진적 감소를 제안합니다.",
-          confidence: 78,
-          priority: "medium" as const,
-        },
-        {
-          id: "sleep-trend-analysis-001",
-          type: "positive" as const,
-          title: "수면 품질이 지속적으로 개선되는 긍정적 추세입니다",
-          description:
-            "최근 7일간 평균 수면 품질 점수 82점으로, 지난 주 대비 12% 향상되었습니다. 특히 습도 관리와 심박수 안정화가 주요 개선 요인으로 분석됩니다. 현재 환경 설정을 유지하시기 바랍니다.",
-          confidence: 94,
-          priority: "low" as const,
-        },
-      ],
-      generatedAt: new Date().toISOString(),
-    },
-  },
-  prediction: {
-    success: true,
-    data: {
-      qualityScore: 84,
-      reasoning:
-        "현재 환경 조건과 최근 수면 패턴을 종합 분석한 결과, 오늘 밤 수면 품질은 84점으로 예상됩니다. 습도와 심박수가 모두 최적 범위에 있으며, 지난 3일간의 긍정적 트렌드가 지속될 것으로 보입니다. 특히 가습기와 스피커의 적절한 설정이 안정적인 수면 환경을 조성하고 있어 높은 품질의 수면이 기대됩니다.",
-      factors: [
-        {
-          name: "습도 조건",
-          impact: "positive" as const,
-          value: "최적 범위 (45%)",
-          explanation:
-            "현재 습도는 수면에 이상적인 40-60% 범위 내에 있어 호흡기 편안함과 피부 건조 방지에 도움이 됩니다.",
-        },
-        {
-          name: "심박수 안정성",
-          impact: "positive" as const,
-          value: "안정적 (65bpm)",
-          explanation: "수면 전 심박수가 안정적이어서 빠른 수면 진입과 깊은 수면 단계 도달이 예상됩니다.",
-        },
-        {
-          name: "환경 제어 시스템",
-          impact: "positive" as const,
-          value: "자동화 최적 설정",
-          explanation: "가습기와 스피커가 적절히 설정되어 밤새 일관된 수면 환경을 유지할 것으로 예상됩니다.",
-        },
-        {
-          name: "최근 수면 트렌드",
-          impact: "positive" as const,
-          value: "지속적 개선",
-          explanation: "지난 주 대비 수면 품질이 꾸준히 향상되고 있어 오늘 밤도 좋은 결과가 기대됩니다.",
-        },
-      ],
-      generatedAt: new Date().toISOString(),
-    },
-  },
-  trends: {
-    success: true,
-    data: {
-      weeklyAnalysis:
-        "이번 주 수면 환경 분석 결과, 전반적으로 매우 긍정적인 변화를 보이고 있습니다. 습도 관리 시스템의 효율성이 크게 개선되어 변동폭이 15% 감소했으며, 심박수도 평균 3bpm 안정화되는 추세를 보입니다. 특히 주중에는 일정한 패턴을 유지하고 있으나, 주말에 약간의 불규칙성이 관찰되었습니다. 현재 설정된 자동화 시스템이 매우 효과적으로 작동하고 있어, 이 상태를 유지하시면 더욱 향상된 수면 품질을 기대할 수 있습니다. 다만 주말 수면 스케줄의 일관성 유지에 더 신경 쓰시기 바랍니다.",
-      humidityTrend: {
-        current: 45,
-        weeklyAverage: 47,
-        trend: "stable" as const,
-        analysis:
-          "습도가 매우 안정적으로 유지되고 있습니다. 가습기 자동화 설정의 효과로 최적 범위를 벗어나는 빈도가 지난 주 대비 60% 감소했습니다. 특히 야간 시간대의 습도 일관성이 크게 개선되어 수면 중 호흡기 불편함이 현저히 줄어들 것으로 예상됩니다.",
-      },
-      heartRateTrend: {
-        current: 65,
-        weeklyAverage: 68,
-        trend: "improving" as const,
-        analysis:
-          "심박수가 지속적으로 개선되고 있는 매우 긍정적인 추세입니다. 스트레스 관리 기법과 이완 음악의 복합적 효과가 나타나고 있으며, 특히 수면 전 1시간 동안의 심박수 안정화가 뚜렷하게 관찰됩니다. 이는 더 빠른 수면 진입과 깊은 수면 단계 유지에 도움이 될 것입니다.",
-      },
-      generatedAt: new Date().toISOString(),
-    },
-  },
-}
-
 // Node.js 서버 API 호출 함수들
-const API_BASE_URL = "/api/sleep-analysis"
-
 export async function fetchInsights(request: SleepAnalysisRequest): Promise<InsightsResponse> {
   try {
-    // 실제 서버 연결 시 사용할 코드
-    /*
-    const response = await fetch(`${API_BASE_URL}/insights`, {
+    const response = await fetch(API_ENDPOINTS.SLEEP_ANALYSIS.INSIGHTS, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -196,11 +88,6 @@ export async function fetchInsights(request: SleepAnalysisRequest): Promise<Insi
     }
     
     return await response.json()
-    */
-
-    // 임시 더미 데이터 (서버 응답 시뮬레이션)
-    await new Promise((resolve) => setTimeout(resolve, 1000 + Math.random() * 2000))
-    return DUMMY_RESPONSES.insights
   } catch (error) {
     return {
       success: false,
@@ -212,9 +99,7 @@ export async function fetchInsights(request: SleepAnalysisRequest): Promise<Insi
 
 export async function fetchPrediction(request: SleepAnalysisRequest): Promise<PredictionResponse> {
   try {
-    // 실제 서버 연결 시 사용할 코드
-    /*
-    const response = await fetch(`${API_BASE_URL}/prediction`, {
+    const response = await fetch(API_ENDPOINTS.SLEEP_ANALYSIS.PREDICTION, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -227,11 +112,6 @@ export async function fetchPrediction(request: SleepAnalysisRequest): Promise<Pr
     }
     
     return await response.json()
-    */
-
-    // 임시 더미 데이터 (서버 응답 시뮬레이션)
-    await new Promise((resolve) => setTimeout(resolve, 1500 + Math.random() * 2000))
-    return DUMMY_RESPONSES.prediction
   } catch (error) {
     return {
       success: false,
@@ -248,9 +128,7 @@ export async function fetchPrediction(request: SleepAnalysisRequest): Promise<Pr
 
 export async function fetchTrends(request: SleepAnalysisRequest): Promise<TrendsResponse> {
   try {
-    // 실제 서버 연결 시 사용할 코드
-    /*
-    const response = await fetch(`${API_BASE_URL}/trends`, {
+    const response = await fetch(API_ENDPOINTS.SLEEP_ANALYSIS.TRENDS, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -263,11 +141,6 @@ export async function fetchTrends(request: SleepAnalysisRequest): Promise<Trends
     }
     
     return await response.json()
-    */
-
-    // 임시 더미 데이터 (서버 응답 시뮬레이션)
-    await new Promise((resolve) => setTimeout(resolve, 2000 + Math.random() * 1000))
-    return DUMMY_RESPONSES.trends
   } catch (error) {
     return {
       success: false,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -122,4 +122,104 @@ router.post("/settings/automation", (req, res) => {
   });
 });
 
+// AI 수면환경 분석 API
+// 인사이트 분석
+router.post("/sleep-analysis/insights", (req, res) => {
+  const { currentEnvironment, sleepHistory } = req.body;
+
+  // 더미 응답 데이터 -> Gemini API 한테 프롬프팅으로 받을 예정
+  const insights = [
+    {
+      id: "humidity-analysis-001",
+      type: "warning",
+      title: "습도 변동이 수면 품질에 영향을 줄 수 있습니다",
+      description:
+        "현재 습도 45%는 적정 범위이지만, 최근 3일간 38%~52% 사이에서 큰 변동을 보이고 있습니다. 일정한 습도 유지를 위해 가습기 자동화 설정을 더 세밀하게 조정하는 것을 권장합니다.",
+      confidence: 87,
+      priority: "medium",
+    },
+    {
+      id: "heartrate-analysis-001",
+      type: "info",
+      title: "심박수가 이상적인 수면 준비 상태를 보여줍니다",
+      description:
+        "현재 심박수 65bpm은 수면 전 최적 상태입니다. 지난 주 평균 68bpm에서 3bpm 감소하여 스트레스 관리와 이완 기법이 효과적으로 작용하고 있는 것으로 분석됩니다.",
+      confidence: 92,
+      priority: "low",
+    },
+  ];
+
+  res.json({
+    success: true,
+    data: {
+      insights,
+      generatedAt: new Date().toISOString(),
+    },
+  });
+});
+
+// 수면 품질 예측
+router.post("/sleep-analysis/prediction", (req, res) => {
+  const { currentEnvironment, sleepHistory } = req.body;
+
+  // 더미 응답 데이터
+  const prediction = {
+    qualityScore: 84,
+    reasoning:
+      "현재 환경 조건과 최근 수면 패턴을 종합 분석한 결과, 오늘 밤 수면 품질은 84점으로 예상됩니다. 습도와 심박수가 모두 최적 범위에 있으며, 지난 3일간의 긍정적 트렌드가 지속될 것으로 보입니다.",
+    factors: [
+      {
+        name: "습도 조건",
+        impact: "positive",
+        value: "최적 범위 (45%)",
+        explanation:
+          "현재 습도는 수면에 이상적인 40-60% 범위 내에 있어 호흡기 편안함과 피부 건조 방지에 도움이 됩니다.",
+      },
+      {
+        name: "심박수 안정성",
+        impact: "positive",
+        value: "안정적 (65bpm)",
+        explanation: "수면 전 심박수가 안정적이어서 빠른 수면 진입과 깊은 수면 단계 도달이 예상됩니다.",
+      },
+    ],
+    generatedAt: new Date().toISOString(),
+  };
+
+  res.json({
+    success: true,
+    data: prediction,
+  });
+});
+
+// 수면 트렌드 분석
+router.post("/sleep-analysis/trends", (req, res) => {
+  const { currentEnvironment, sleepHistory } = req.body;
+
+  // 더미 응답 데이터
+  const trends = {
+    weeklyAnalysis:
+      "이번 주 수면 환경 분석 결과, 전반적으로 매우 긍정적인 변화를 보이고 있습니다. 습도 관리 시스템의 효율성이 크게 개선되어 변동폭이 15% 감소했으며, 심박수도 평균 3bpm 안정화되는 추세를 보입니다.",
+    humidityTrend: {
+      current: 45,
+      weeklyAverage: 47,
+      trend: "stable",
+      analysis:
+        "습도가 매우 안정적으로 유지되고 있습니다. 가습기 자동화 설정의 효과로 최적 범위를 벗어나는 빈도가 지난 주 대비 60% 감소했습니다.",
+    },
+    heartRateTrend: {
+      current: 65,
+      weeklyAverage: 68,
+      trend: "improving",
+      analysis:
+        "심박수가 지속적으로 개선되고 있는 매우 긍정적인 추세입니다. 스트레스 관리 기법과 이완 음악의 복합적 효과가 나타나고 있습니다.",
+    },
+    generatedAt: new Date().toISOString(),
+  };
+
+  res.json({
+    success: true,
+    data: trends,
+  });
+});
+
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -6,10 +6,15 @@ require("dotenv").config();
 const apiRouter = require("./routes/api");
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 4000;
+
+// CORS 설정
+app.use(cors({
+  origin: 'http://localhost:3000', // Next.js 클라이언트 주소
+  credentials: true
+}));
 
 // 미들웨어 설정
-app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
- 클라이언트에서 더미데이터로 화면을 뿌리는 것을 제거하고 NodeJs서버와 API 연결함
  - 3000포트가 NextJs에서 쓰고 있어서 NodeJS 서버의 포트를 4000번으로 변경함
- 엔드포인트에서 아직 서비스 로직은 미구현이고, 클라에서 내려주던 데이터를 더미 객체로 가지고 있다가 내려보내줌
- 후속으로 서비스 구현 필요